### PR TITLE
Release v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "annotate-image",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0",
   "description": "Create Flickr-like comment annotations on images — draw rectangles, add notes, save via AJAX or static data",
   "license": "GPL-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump version from `2.0.0-beta.5` to `2.0.0` for stable release

The `v2.0.0` tag has already been pushed. Once this PR merges, the release workflow will be re-triggered.