### PR TITLE
Ignore major version bumps for pinned dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,25 @@ updates:
     day: monday
     time: "04:00"
   open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: "@types/jquery"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "@types/react"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "@types/react-dom"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "jquery"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "react"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "react-dom"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "eslint"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "@eslint/js"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "jsdom"
+      update-types: ["version-update:semver-major"]
   groups:
     all-npm-updates:
       patterns:


### PR DESCRIPTION
## Summary

- Adds `ignore` rules to `.github/dependabot.yml` to prevent dependabot from proposing breaking major version bumps on dev dependencies that are intentionally pinned to specific major versions
- PR #47 failed CI because dependabot bumped `@types/jquery` 3→4, `jquery` 3→4, `react`/`react-dom` 18→19, `eslint` 9→10, and `jsdom` 28→30

## Ignored packages

| Package | Reason |
|---------|--------|
| `@types/jquery`, `jquery` | Plugin targets jQuery 3.x |
| `@types/react`, `react`, `react-dom` | Component targets React 18.x |
| `eslint`, `@eslint/js` | v10 requires config migration |
| `jsdom` | v30 needs compatibility review |

## Test plan

- [ ] CI passes
- [ ] After merge, `@dependabot recreate` on PR #47 produces a PR without the major bumps